### PR TITLE
Fixing display for 5 digit build numbers

### DIFF
--- a/widgets/server_status_squares/server_status_squares.scss
+++ b/widgets/server_status_squares/server_status_squares.scss
@@ -42,7 +42,8 @@ $label-color:       rgba(255, 255, 255, 0.7);
 
   .value {
     float: right;
-    margin-left: 12px;
+    margin-left: 10px;
+    margin-bottom: 20px;
     font-weight: 600;
     color: $value-color;
   }


### PR DESCRIPTION
The new orb adds the git hash to the version number which screws up the display for 5 digit build numbers.

Before:
<kbd>
<img width="236" alt="Screenshot 2020-04-15 at 08 41 11" src="https://user-images.githubusercontent.com/1517745/79312003-2d94c300-7ef6-11ea-83b2-705257c8d8ac.png">
</kbd>

After:
<kbd>
<img width="312" alt="Screenshot 2020-04-15 at 08 45 08" src="https://user-images.githubusercontent.com/1517745/79312050-3daca280-7ef6-11ea-9d30-1eb17bdc8deb.png">
</kbd>