### PR TITLE
PAT-785  Add pathfinder API to DPS monitor

### DIFF
--- a/dashboards/circle.erb
+++ b/dashboards/circle.erb
@@ -62,6 +62,9 @@
     <li data-row="3" data-col="5" data-sizex="1" data-sizey="1">
       <div data-id="circle-ci-ministryofjustice-offender-case-notes-master" data-view="CircleCi" data-title="Offender Case Notes"></div>
     </li>
+    <li data-row="3" data-col="6" data-sizex="1" data-sizey="1">
+      <div data-id="circle-ci-ministryofjustice-pathfinder-api-master" data-view="CircleCi" data-title="Pathfinder API"></div>
+    </li>
 
 
     <li data-row="4" data-col="1" data-sizex="1" data-sizey="1">

--- a/dashboards/health.erb
+++ b/dashboards/health.erb
@@ -44,6 +44,7 @@ $(function() {
       <li data-row="1" data-col="12" data-sizex="1" data-sizey="1">
         <div data-id="check-my-diary-prod" data-view="ServerStatusSquares" data-title="Check My Diary - Prod"></div>
       </li>
+
       <li data-row="2" data-col="1" data-sizex="1" data-sizey="1">
         <div data-id="oauth2-preprod" data-view="ServerStatusSquares" data-title="OAUTH2 Server - PreProd"></div>
       </li>
@@ -117,6 +118,7 @@ $(function() {
       <li data-row="3" data-col="12" data-sizex="1" data-sizey="1">
         <div data-id="check-my-diary-dev" data-view="ServerStatusSquares" data-title="Check My Diary - Dev"></div>
       </li>
+
       <li data-row="5" data-col="1" data-sizex="1" data-sizey="1">
         <div data-id="offender-events-prod" data-view="ServerStatusSquares" data-title="Offender Events - Prod"></div>
       </li>
@@ -231,17 +233,28 @@ $(function() {
       <li data-row="9" data-col="2" data-sizex="1" data-sizey="1">
         <div data-id="prisoner-offender-search-prod" data-view="ServerStatusSquares" data-title="Prisoner Search - Prod"></div>
       </li>
+      <li data-row="9" data-col="3" data-sizex="1" data-sizey="1">
+        <div data-id="pathfinder-api-prod" data-view="ServerStatusSquares" data-title="Pathfinder API - Prod"></div>
+      </li>
+
       <li data-row="10" data-col="1" data-sizex="1" data-sizey="1">
         <div data-id="token-verification-api-preprod" data-view="ServerStatusSquares" data-title="Token Verification Api - PreProd"></div>
       </li>
       <li data-row="10" data-col="2" data-sizex="1" data-sizey="1">
         <div data-id="prisoner-offender-search-preprod" data-view="ServerStatusSquares" data-title="Prisoner Search - PreProd"></div>
       </li>
+      <li data-row="10" data-col="3" data-sizex="1" data-sizey="1">
+        <div data-id="pathfinder-api-preprod" data-view="ServerStatusSquares" data-title="Pathfinder API - PreProd"></div>
+      </li>
+
       <li data-row="11" data-col="1" data-sizex="1" data-sizey="1">
         <div data-id="token-verification-api-dev" data-view="ServerStatusSquares" data-title="Token Verification Api - Dev"></div>
       </li>
       <li data-row="11" data-col="2" data-sizex="1" data-sizey="1">
         <div data-id="prisoner-offender-search-dev" data-view="ServerStatusSquares" data-title="Prisoner Search - Dev"></div>
+      </li>
+      <li data-row="11" data-col="3" data-sizex="1" data-sizey="1">
+        <div data-id="pathfinder-api-dev" data-view="ServerStatusSquares" data-title="Pathfinder API - Dev"></div>
       </li>
 
     </ul>

--- a/dashboards/overview.erb
+++ b/dashboards/overview.erb
@@ -1,7 +1,7 @@
 <script type='text/javascript'>
     $(function() {
-        Dashing.widget_base_dimensions = [280, 400]
-        Dashing.numColumns = 12
+        Dashing.widget_base_dimensions = [320, 400]
+        Dashing.numColumns = 9
     });
 </script>
 
@@ -35,129 +35,139 @@
     <li data-row="1" data-col="9" data-sizex="1" data-sizey="1">
       <div data-id="prison-to-probation-update-prod" data-view="ServerStatusSquares" data-title="Prison to Probation Update"></div>
     </li>
-    <li data-row="1" data-col="10" data-sizex="1" data-sizey="1">
-      <div data-id="prison-estate-prod" data-view="ServerStatusSquares" data-title="Prison Estate"></div>
-    </li>
-    <li data-row="1" data-col="11" data-sizex="1" data-sizey="1">
-      <div data-id="pathfinder-prod" data-view="ServerStatusSquares" data-title="Pathfinder"></div>
-    </li>
-    <li data-row="1" data-col="12" data-sizex="1" data-sizey="1">
-      <div data-id="check-my-diary-prod" data-view="ServerStatusSquares" data-title="Check My Diary"></div>
-    </li>
 
     <li data-row="2" data-col="1" data-sizex="1" data-sizey="1">
-      <div data-id="dps-core-prod" data-view="ServerStatusSquares" data-title="DPS Core"></div>
+      <div data-id="prison-estate-prod" data-view="ServerStatusSquares" data-title="Prison Estate"></div>
     </li>
     <li data-row="2" data-col="2" data-sizex="1" data-sizey="1">
-      <div data-id="omic-ui-prod" data-view="ServerStatusSquares" data-title="Keyworker UI"></div>
+      <div data-id="pathfinder-prod" data-view="ServerStatusSquares" data-title="Pathfinder"></div>
     </li>
     <li data-row="2" data-col="3" data-sizex="1" data-sizey="1">
-      <div data-id="whereabouts-prod" data-view="ServerStatusSquares" data-title="Whereabouts UI"></div>
+      <div data-id="check-my-diary-prod" data-view="ServerStatusSquares" data-title="Check My Diary"></div>
     </li>
     <li data-row="2" data-col="4" data-sizex="1" data-sizey="1">
-      <div data-id="cat-tool-prod" data-view="ServerStatusSquares" data-title="Dig Cat Tool"></div>
+      <div data-id="dps-core-prod" data-view="ServerStatusSquares" data-title="DPS Core"></div>
     </li>
     <li data-row="2" data-col="5" data-sizex="1" data-sizey="1">
-      <div data-id="licences-prod" data-view="ServerStatusSquares" data-title="Licences"></div>
+      <div data-id="omic-ui-prod" data-view="ServerStatusSquares" data-title="Keyworker UI"></div>
     </li>
     <li data-row="2" data-col="6" data-sizex="1" data-sizey="1">
-      <div data-id="case-notes-to-probation-prod" data-view="ServerStatusSquares" data-title="Case Notes to Probation"></div>
+      <div data-id="whereabouts-prod" data-view="ServerStatusSquares" data-title="Whereabouts UI"></div>
     </li>
     <li data-row="2" data-col="7" data-sizex="1" data-sizey="1">
-      <div data-id="offender-events-prod" data-view="ServerStatusSquares" data-title="Offender Events"></div>
+      <div data-id="cat-tool-prod" data-view="ServerStatusSquares" data-title="Dig Cat Tool"></div>
     </li>
     <li data-row="2" data-col="8" data-sizex="1" data-sizey="1">
-      <div data-id="prisoner-offender-search-prod" data-view="ServerStatusSquares" data-title="Prisoner Search"></div>
+      <div data-id="licences-prod" data-view="ServerStatusSquares" data-title="Licences"></div>
     </li>
     <li data-row="2" data-col="9" data-sizex="1" data-sizey="1">
-      <div data-id="probation-teams-prod" data-view="ServerStatusSquares" data-title="Probation Teams"></div>
+      <div data-id="case-notes-to-probation-prod" data-view="ServerStatusSquares" data-title="Case Notes to Probation"></div>
     </li>
-    <li data-row="2" data-col="10" data-sizex="1" data-sizey="1">
-      <div data-id="prison-to-nhs-update-prod" data-view="ServerStatusSquares" data-title="Prison to NHS"></div>
-    </li>
-    <li data-row="2" data-col="11" data-sizex="1" data-sizey="1">
-      <div data-id="offender-search-prod" data-view="ServerStatusSquares" data-title="Offender Search"></div>
-    </li>
-    <li data-row="2" data-col="12" data-sizex="1" data-sizey="1">
-      <div data-id="token-verification-api-prod" data-view="ServerStatusSquares" data-title="Token Verification Api"></div>
-    </li>
-
 
     <li data-row="3" data-col="1" data-sizex="1" data-sizey="1">
-      <div data-id="circle-ci-ministryofjustice-nomis-oauth2-server-master" data-view="CircleCi" data-title="Auth Server"></div>
+      <div data-id="offender-events-prod" data-view="ServerStatusSquares" data-title="Offender Events"></div>
     </li>
     <li data-row="3" data-col="2" data-sizex="1" data-sizey="1">
-      <div data-id="circle-ci-ministryofjustice-elite2-api-master" data-view="CircleCi" data-title="Elite2 Api"></div>
+      <div data-id="prisoner-offender-search-prod" data-view="ServerStatusSquares" data-title="Prisoner Search"></div>
     </li>
     <li data-row="3" data-col="3" data-sizex="1" data-sizey="1">
-      <div data-id="circle-ci-ministryofjustice-custody-api-master" data-view="CircleCi" data-title="Custody Api"></div>
+      <div data-id="probation-teams-prod" data-view="ServerStatusSquares" data-title="Probation Teams"></div>
     </li>
     <li data-row="3" data-col="4" data-sizex="1" data-sizey="1">
-      <div data-id="circle-ci-ministryofjustice-keyworker-service-master" data-view="CircleCi" data-title="Keyworker Api"></div>
+      <div data-id="prison-to-nhs-update-prod" data-view="ServerStatusSquares" data-title="Prison to NHS"></div>
     </li>
     <li data-row="3" data-col="5" data-sizex="1" data-sizey="1">
-      <div data-id="circle-ci-ministryofjustice-whereabouts-api-master" data-view="CircleCi" data-title="Whereabouts Api"></div>
+      <div data-id="offender-search-prod" data-view="ServerStatusSquares" data-title="Offender Search"></div>
     </li>
     <li data-row="3" data-col="6" data-sizex="1" data-sizey="1">
-      <div data-id="circle-ci-ministryofjustice-offender-case-notes-master" data-view="CircleCi" data-title="Offender Case Notes"></div>
+      <div data-id="token-verification-api-prod" data-view="ServerStatusSquares" data-title="Token Verification Api"></div>
     </li>
     <li data-row="3" data-col="7" data-sizex="1" data-sizey="1">
-      <div data-id="circle-ci-ministryofjustice-offender-risk-profiler-master" data-view="CircleCi" data-title="Offender Risk Profiler Api"></div>
-    </li>
-    <li data-row="3" data-col="8" data-sizex="1" data-sizey="1">
-      <div data-id="circle-ci-ministryofjustice-community-api-master" data-view="CircleCi" data-title="Community API"></div>
-    </li>
-    <li data-row="3" data-col="9" data-sizex="1" data-sizey="1">
-      <div data-id="circle-ci-ministryofjustice-prison-to-probation-update-master" data-view="CircleCi" data-title="Prison to Probation Update"></div>
-    </li>
-    <li data-row="3" data-col="10" data-sizex="1" data-sizey="1">
-      <div data-id="circle-ci-ministryofjustice-prison-estate-master" data-view="CircleCi" data-title="Prison Estate"></div>
-    </li>
-    <li data-row="3" data-col="11" data-sizex="1" data-sizey="1">
-      <div data-id="circle-ci-ministryofjustice-pathfinder-master" data-view="CircleCi" data-title="Pathfinder"></div>
-    </li>
-    <li data-row="3" data-col="12" data-sizex="1" data-sizey="1">
-      <div data-id="circle-ci-ministryofjustice-check-my-diary-master" data-view="CircleCi" data-title="Check My Diary"></div>
+      <div data-id="pathfinder-api-prod" data-view="ServerStatusSquares" data-title="Pathfinder API"></div>
     </li>
 
     <li data-row="4" data-col="1" data-sizex="1" data-sizey="1">
-      <div data-id="circle-ci-ministryofjustice-new-nomis-ui-master" data-view="CircleCi" data-title="DPS Core"></div>
+      <div data-id="circle-ci-ministryofjustice-nomis-oauth2-server-master" data-view="CircleCi" data-title="Auth Server"></div>
     </li>
     <li data-row="4" data-col="2" data-sizex="1" data-sizey="1">
-      <div data-id="circle-ci-ministryofjustice-keyworker-ui-master" data-view="CircleCi" data-title="Keyworker UI"></div>
+      <div data-id="circle-ci-ministryofjustice-elite2-api-master" data-view="CircleCi" data-title="Elite2 Api"></div>
     </li>
     <li data-row="4" data-col="3" data-sizex="1" data-sizey="1">
-      <div data-id="circle-ci-ministryofjustice-prisonstaffhub-master" data-view="CircleCi" data-title="Whereabouts UI"></div>
+      <div data-id="circle-ci-ministryofjustice-custody-api-master" data-view="CircleCi" data-title="Custody Api"></div>
     </li>
     <li data-row="4" data-col="4" data-sizex="1" data-sizey="1">
-      <div data-id="circle-ci-ministryofjustice-categorisation-tool-master" data-view="CircleCi" data-title="Dig Cat Tool"></div>
+      <div data-id="circle-ci-ministryofjustice-keyworker-service-master" data-view="CircleCi" data-title="Keyworker Api"></div>
     </li>
     <li data-row="4" data-col="5" data-sizex="1" data-sizey="1">
-      <div data-id="circle-ci-ministryofjustice-licences-master" data-view="CircleCi" data-title="Licences"></div>
+      <div data-id="circle-ci-ministryofjustice-whereabouts-api-master" data-view="CircleCi" data-title="Whereabouts Api"></div>
     </li>
     <li data-row="4" data-col="6" data-sizex="1" data-sizey="1">
-      <div data-id="circle-ci-ministryofjustice-case-notes-poll-push-master" data-view="CircleCi" data-title="Case Notes to Probation"></div>
+      <div data-id="circle-ci-ministryofjustice-offender-case-notes-master" data-view="CircleCi" data-title="Offender Case Notes"></div>
     </li>
     <li data-row="4" data-col="7" data-sizex="1" data-sizey="1">
-      <div data-id="circle-ci-ministryofjustice-offender-events-master" data-view="CircleCi" data-title="Offender Events"></div>
+      <div data-id="circle-ci-ministryofjustice-use-of-force-master" data-view="CircleCi" data-title="Use of Force"></div>
     </li>
     <li data-row="4" data-col="8" data-sizex="1" data-sizey="1">
-      <div data-id="circle-ci-ministryofjustice-dps-data-compliance-master" data-view="CircleCi" data-title="Data Compliance"></div>
+      <div data-id="circle-ci-ministryofjustice-community-api-master" data-view="CircleCi" data-title="Community API"></div>
     </li>
     <li data-row="4" data-col="9" data-sizex="1" data-sizey="1">
+      <div data-id="circle-ci-ministryofjustice-prison-to-probation-update-master" data-view="CircleCi" data-title="Prison to Probation Update"></div>
+    </li>
+
+    <li data-row="5" data-col="1" data-sizex="1" data-sizey="1">
+      <div data-id="circle-ci-ministryofjustice-prison-estate-master" data-view="CircleCi" data-title="Prison Estate"></div>
+    </li>
+    <li data-row="5" data-col="2" data-sizex="1" data-sizey="1">
+      <div data-id="circle-ci-ministryofjustice-pathfinder-master" data-view="CircleCi" data-title="Pathfinder"></div>
+    </li>
+    <li data-row="5" data-col="3" data-sizex="1" data-sizey="1">
+      <div data-id="circle-ci-ministryofjustice-check-my-diary-master" data-view="CircleCi" data-title="Check My Diary"></div>
+    </li>
+    <li data-row="5" data-col="4" data-sizex="1" data-sizey="1">
+      <div data-id="circle-ci-ministryofjustice-new-nomis-ui-master" data-view="CircleCi" data-title="DPS Core"></div>
+    </li>
+    <li data-row="5" data-col="5" data-sizex="1" data-sizey="1">
+      <div data-id="circle-ci-ministryofjustice-keyworker-ui-master" data-view="CircleCi" data-title="Keyworker UI"></div>
+    </li>
+    <li data-row="5" data-col="6" data-sizex="1" data-sizey="1">
+      <div data-id="circle-ci-ministryofjustice-prisonstaffhub-master" data-view="CircleCi" data-title="Whereabouts UI"></div>
+    </li>
+    <li data-row="5" data-col="7" data-sizex="1" data-sizey="1">
+      <div data-id="circle-ci-ministryofjustice-categorisation-tool-master" data-view="CircleCi" data-title="Dig Cat Tool"></div>
+    </li>
+    <li data-row="5" data-col="8" data-sizex="1" data-sizey="1">
+      <div data-id="circle-ci-ministryofjustice-licences-master" data-view="CircleCi" data-title="Licences"></div>
+    </li>
+    <li data-row="5" data-col="9" data-sizex="1" data-sizey="1">
+      <div data-id="circle-ci-ministryofjustice-case-notes-poll-push-master" data-view="CircleCi" data-title="Case Notes to Probation"></div>
+    </li>
+
+    <li data-row="6" data-col="1" data-sizex="1" data-sizey="1">
+      <div data-id="circle-ci-ministryofjustice-offender-events-master" data-view="CircleCi" data-title="Offender Events"></div>
+    </li>
+    <li data-row="6" data-col="2" data-sizex="1" data-sizey="1">
+      <div data-id="circle-ci-ministryofjustice-prisoner-offender-search-master" data-view="CircleCi" data-title="Prisoner Search"></div>
+    </li>
+    <li data-row="6" data-col="3" data-sizex="1" data-sizey="1">
       <div data-id="circle-ci-ministryofjustice-probation-teams-master" data-view="CircleCi" data-title="Probation Teams"></div>
     </li>
-    <li data-row="4" data-col="10" data-sizex="1" data-sizey="1">
+    <li data-row="6" data-col="4" data-sizex="1" data-sizey="1">
       <div data-id="circle-ci-ministryofjustice-prison-to-nhs-update-master" data-view="CircleCi" data-title="Prison to NHS"></div>
     </li>
-    <li data-row="4" data-col="11" data-sizex="1" data-sizey="1">
+    <li data-row="6" data-col="5" data-sizex="1" data-sizey="1">
       <div data-id="circle-ci-ministryofjustice-offender-search-master" data-view="CircleCi" data-title="Offender Search"></div>
     </li>
-    <li data-row="4" data-col="12" data-sizex="1" data-sizey="1">
+    <li data-row="6" data-col="6" data-sizex="1" data-sizey="1">
       <div data-id="circle-ci-ministryofjustice-token-verification-api-master" data-view="CircleCi" data-title="Token Verification Api"></div>
     </li>
-    <li data-row="5" data-col="1" data-sizex="1" data-sizey="1">
-      <div data-id="circle-ci-ministryofjustice-prisoner-offender-search-master" data-view="CircleCi" data-title="Prisoner Search"></div>
+    <li data-row="6" data-col="7" data-sizex="1" data-sizey="1">
+      <div data-id="circle-ci-ministryofjustice-pathfinder-api-master" data-view="CircleCi" data-title="Pathfinder API"></div>
+    </li>
+    <li data-row="6" data-col="8" data-sizex="1" data-sizey="1">
+      <div data-id="circle-ci-ministryofjustice-dps-data-compliance-master" data-view="CircleCi" data-title="Data Compliance"></div>
+    </li>
+    <li data-row="6" data-col="9" data-sizex="1" data-sizey="1">
+      <div data-id="circle-ci-ministryofjustice-offender-risk-profiler-master" data-view="CircleCi" data-title="Offender Risk Profiler Api"></div>
     </li>
   </ul>
 </div>

--- a/dashboards/pathfinder-overview.erb
+++ b/dashboards/pathfinder-overview.erb
@@ -30,6 +30,9 @@
     <li data-row="1" data-col="7" data-sizex="1" data-sizey="1">
       <div data-id="offender-search-prod" data-view="ServerStatusSquares" data-title="Offender Search - Prod"></div>
     </li>
+    <li data-row="1" data-col="8" data-sizex="1" data-sizey="1">
+      <div data-id="pathfinder-api-prod" data-view="ServerStatusSquares" data-title="Pathfinder API - Prod"></div>
+    </li>
 
 
     <li data-row="2" data-col="1" data-sizex="1" data-sizey="1">
@@ -52,6 +55,9 @@
     </li>
     <li data-row="2" data-col="7" data-sizex="1" data-sizey="1">
       <div data-id="offender-search-preprod" data-view="ServerStatusSquares" data-title="Offender Search - PreProd"></div>
+    </li>
+    <li data-row="2" data-col="8" data-sizex="1" data-sizey="1">
+      <div data-id="pathfinder-api-preprod" data-view="ServerStatusSquares" data-title="Pathfinder API - PreProd"></div>
     </li>
 
 
@@ -76,6 +82,9 @@
     <li data-row="3" data-col="7" data-sizex="1" data-sizey="1">
       <div data-id="offender-search-dev" data-view="ServerStatusSquares" data-title="Offender Search - Dev"></div>
     </li>
+    <li data-row="3" data-col="8" data-sizex="1" data-sizey="1">
+      <div data-id="pathfinder-api-dev" data-view="ServerStatusSquares" data-title="Pathfinder API - Dev"></div>
+    </li>
 
 
     <li data-row="4" data-col="1" data-sizex="1" data-sizey="1">
@@ -98,6 +107,9 @@
     </li>
     <li data-row="4" data-col="7" data-sizex="1" data-sizey="1">
       <div data-id="circle-ci-ministryofjustice-offender-search-master" data-view="CircleCi" data-title="Offender Search"></div>
+    </li>
+    <li data-row="4" data-col="8" data-sizex="1" data-sizey="1">
+      <div data-id="circle-ci-ministryofjustice-pathfinder-api-master" data-view="CircleCi" data-title="Pathfinder API"></div>
     </li>
 
   </ul>

--- a/jobs/circle_ci.rb
+++ b/jobs/circle_ci.rb
@@ -31,6 +31,7 @@ projects = [
   { vcs: 'github', user: 'ministryofjustice', repo: 'check-my-diary', branch: 'master'},
   { vcs: 'github', user: 'ministryofjustice', repo: 'token-verification-api', branch: 'master'},
   { vcs: 'github', user: 'ministryofjustice', repo: 'prisoner-offender-search', branch: 'master'},
+  { vcs: 'github', user: 'ministryofjustice', repo: 'pathfinder-api', branch: 'master'},
 ]
 
 def duration(time)

--- a/jobs/health.rb
+++ b/jobs/health.rb
@@ -56,6 +56,7 @@ prod_servers = [
     {name: 'token-verification-api', versionUrl: 'https://token-verification-api.prison.service.justice.gov.uk/info', url: 'https://token-verification-api.prison.service.justice.gov.uk/health'},
     {name: 'prison-to-nhs-update', versionUrl: 'https://prison-to-nhs-update.prison.service.justice.gov.uk/info', url: 'https://prison-to-nhs-update.prison.service.justice.gov.uk/health'},
     {name: 'prisoner-offender-search', versionUrl: 'https://prisoner-offender-search.prison.service.justice.gov.uk/info', url: 'https://prisoner-offender-search.prison.service.justice.gov.uk/health'},
+    {name: 'pathfinder-api', versionUrl: 'https://api.pathfinder.service.justice.gov.uk/info', url: 'https://api.pathfinder.service.justice.gov.uk/health'},
 ]
 
 preprod_servers = [
@@ -85,6 +86,7 @@ preprod_servers = [
     {name: 'token-verification-api', versionUrl: 'https://token-verification-api-preprod.prison.service.justice.gov.uk/info', url: 'https://token-verification-api-preprod.prison.service.justice.gov.uk/health'},
     {name: 'prison-to-nhs-update', versionUrl: 'https://prison-to-nhs-update-preprod.prison.service.justice.gov.uk/info', url: 'https://prison-to-nhs-update-preprod.prison.service.justice.gov.uk/health'},
     {name: 'prisoner-offender-search', versionUrl: 'https://prisoner-offender-search-preprod.prison.service.justice.gov.uk/info', url: 'https://prisoner-offender-search-preprod.prison.service.justice.gov.uk/health'},
+    {name: 'pathfinder-api', versionUrl: 'https://preprod-api.pathfinder.service.justice.gov.uk/info', url: 'https://preprod-api.pathfinder.service.justice.gov.uk/health'},
 ]
 
 dev_servers = [
@@ -116,6 +118,7 @@ dev_servers = [
     {name: 'check-my-diary', url: 'https://check-my-diary-dev.prison.service.justice.gov.uk/health'},
     {name: 'token-verification-api', versionUrl: 'https://token-verification-api-dev.prison.service.justice.gov.uk/info', url: 'https://token-verification-api-dev.prison.service.justice.gov.uk/health'},
     {name: 'prisoner-offender-search', versionUrl: 'https://prisoner-offender-search-dev.prison.service.justice.gov.uk/info', url: 'https://prisoner-offender-search-dev.prison.service.justice.gov.uk/health'},
+    {name: 'pathfinder-api', versionUrl: 'https://dev-api.pathfinder.service.justice.gov.uk/info', url: 'https://dev-api.pathfinder.service.justice.gov.uk/health'},
 ]
 
 # Any service which does not have a preprod instance should be placed in this list.


### PR DESCRIPTION
* Added pathfinder API to health, overview, circle and pathfinder-overview dashboards & jobs
* Aligned all overview service health with their circle builds, in a 6x9 grid - looks good at 33% zoom.
* Added missing circle build to overview for use-of-force
* Left gaps for data-compliance and offender-risk-profiler to add health squares when/if ready.
* Room to extend for further services by adding extra columns