### PR TITLE
PAT-1212: Update manage-soc-cases domain - all environments

### DIFF
--- a/dashboards/health.erb
+++ b/dashboards/health.erb
@@ -29,6 +29,9 @@ $(function() {
       <li data-row="1" data-col="7" data-sizex="1" data-sizey="1">
         <div data-id="whereabouts-api-prod" data-view="ServerStatusSquares" data-title="Whereabouts Api - Prod"></div>
       </li>
+      <li data-row="1" data-col="8" data-sizex="1" data-sizey="1">
+        <div data-id="manage-soc-cases-prod" data-view="ServerStatusSquares" data-title="Manage SOC Cases - Prod"></div>
+      </li>
       <li data-row="1" data-col="9" data-sizex="1" data-sizey="1">
         <div data-id="probation-offender-search-indexer-prod" data-view="ServerStatusSquares" data-title="Probation Search Indexer - Prod"></div>
       </li>
@@ -62,6 +65,9 @@ $(function() {
       </li>
       <li data-row="2" data-col="7" data-sizex="1" data-sizey="1">
         <div data-id="whereabouts-api-preprod" data-view="ServerStatusSquares" data-title="Whereabouts Api - PreProd"></div>
+      </li>
+      <li data-row="2" data-col="8" data-sizex="1" data-sizey="1">
+        <div data-id="manage-soc-cases-preprod" data-view="ServerStatusSquares" data-title="Manage SOC Cases - PreProd"></div>
       </li>
       <li data-row="2" data-col="9" data-sizex="1" data-sizey="1">
         <div data-id="probation-offender-search-indexer-preprod" data-view="ServerStatusSquares" data-title="Probation Search Indexer - PreProd"></div>

--- a/jobs/health.rb
+++ b/jobs/health.rb
@@ -57,6 +57,7 @@ prod_servers = [
     {name: 'prison-to-nhs-update', versionUrl: 'https://prison-to-nhs-update.prison.service.justice.gov.uk/info', url: 'https://prison-to-nhs-update.prison.service.justice.gov.uk/health'},
     {name: 'prisoner-offender-search', versionUrl: 'https://prisoner-offender-search.prison.service.justice.gov.uk/info', url: 'https://prisoner-offender-search.prison.service.justice.gov.uk/health'},
     {name: 'pathfinder-api', versionUrl: 'https://api.pathfinder.service.justice.gov.uk/info', url: 'https://api.pathfinder.service.justice.gov.uk/health'},
+    {name: 'manage-soc-cases', url: 'https://manage-soc-cases.hmpps.service.justice.gov.uk/health'},
     {name: 'probation-offender-search-indexer', versionUrl: 'https://probation-search-indexer.hmpps.service.justice.gov.uk/info', url: 'https://probation-search-indexer.hmpps.service.justice.gov.uk/health'},
 ]
 
@@ -87,6 +88,7 @@ preprod_servers = [
     {name: 'prison-to-nhs-update', versionUrl: 'https://prison-to-nhs-update-preprod.prison.service.justice.gov.uk/info', url: 'https://prison-to-nhs-update-preprod.prison.service.justice.gov.uk/health'},
     {name: 'prisoner-offender-search', versionUrl: 'https://prisoner-offender-search-preprod.prison.service.justice.gov.uk/info', url: 'https://prisoner-offender-search-preprod.prison.service.justice.gov.uk/health'},
     {name: 'pathfinder-api', versionUrl: 'https://preprod-api.pathfinder.service.justice.gov.uk/info', url: 'https://preprod-api.pathfinder.service.justice.gov.uk/health'},
+    {name: 'manage-soc-cases', url: 'https://manage-soc-cases-preprod.hmpps.service.justice.gov.uk/health'},
     {name: 'probation-offender-search-indexer', versionUrl: 'https://probation-search-indexer-preprod.hmpps.service.justice.gov.uk/info', url: 'https://probation-search-indexer-preprod.hmpps.service.justice.gov.uk/health'},
 ]
 
@@ -118,7 +120,7 @@ dev_servers = [
     {name: 'token-verification-api', versionUrl: 'https://token-verification-api-dev.prison.service.justice.gov.uk/info', url: 'https://token-verification-api-dev.prison.service.justice.gov.uk/health'},
     {name: 'prisoner-offender-search', versionUrl: 'https://prisoner-offender-search-dev.prison.service.justice.gov.uk/info', url: 'https://prisoner-offender-search-dev.prison.service.justice.gov.uk/health'},
     {name: 'pathfinder-api', versionUrl: 'https://dev-api.pathfinder.service.justice.gov.uk/info', url: 'https://dev-api.pathfinder.service.justice.gov.uk/health'},
-    {name: 'manage-soc-cases', url: 'https://manage-soc-cases-dev.service.justice.gov.uk/health'},
+    {name: 'manage-soc-cases', url: 'https://manage-soc-cases-dev.hmpps.service.justice.gov.uk/health'},
     {name: 'probation-offender-search-indexer', versionUrl: 'https://probation-search-indexer-dev.hmpps.service.justice.gov.uk/info', url: 'https://probation-search-indexer-dev.hmpps.service.justice.gov.uk/health'},
 ]
 


### PR DESCRIPTION
Alter dev for manage-soc-cases to use the .hmpps.service.justice.gov.uk.
Add preprod and prod environments to the jobs and dashboard for monitoring.