### PR TITLE
CAT-1335: Fix offender-categorisation-dev

### DIFF
--- a/jobs/projects.rb
+++ b/jobs/projects.rb
@@ -87,7 +87,7 @@ module Config
       healthPath: '/healthcheck',
       prodUrl: 'https://health-kick.prison.service.justice.gov.uk/https/offender-categorisation.service.justice.gov.uk',
       preprodUrl: 'https://health-kick.prison.service.justice.gov.uk/https/preprod.offender-categorisation.service.justice.gov.uk',
-      devUrl: 'https://dev.offender-categorisation.service.justice.gov.uk',
+      devUrl: 'https://health-kick.prison.service.justice.gov.uk/https/dev.offender-categorisation.service.justice.gov.uk',
       title: 'Offender Categorisation',
       teams: ['sed'],
     },


### PR DESCRIPTION
Offender-categorisation-dev healthcheck URL was incorrect, it was displayed as:
![image](https://user-images.githubusercontent.com/26416940/203355714-8479c826-0ae7-43c1-b425-e8132fc00cbf.png)
